### PR TITLE
Fixed ordering on LLVM find_package CMake command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(TraceAtlas VERSION 0.1.0)
 
 SET (CMAKE_CXX_STANDARD 17)
 
-find_package(LLVM REQUIRED 8 CONFIG)
+find_package(LLVM 8 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 llvm_map_components_to_libnames(llvm_libs  support core irreader bitreader bitwriter transformutils)


### PR DESCRIPTION
By putting the version after REQUIRED, it was being ignored on a system
with both llvm-7 and llvm-8 installs and thus the llvm-7 includes were
being selected during cmake configuration. After building, this led to a segfault when trying
to utilize the generated opt passes in opt-8

See also: [find_package signature](https://cmake.org/cmake/help/v3.15/command/find_package.html)